### PR TITLE
Bugfix/show help without input

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ go.work
 *.swp
 *.swo
 .DS_Store
+.cursorrules
 
 # Build output
 dist/

--- a/cmd/jp/main.go
+++ b/cmd/jp/main.go
@@ -344,6 +344,7 @@ func ParseFlags() (string, string, error) {
 	flagSet.BoolVar(&cfg.compact, "c", false, "Compact output")
 	flagSet.BoolVar(&cfg.noColor, "no-color", false, "Disable colored output")
 	flagSet.BoolVar(&help, "h", false, "Show help")
+	flagSet.BoolVar(&help, "help", false, "Show help")
 	flagSet.BoolVar(&version, "v", false, "Show version")
 
 	if err := flagSet.Parse(os.Args[1:]); err != nil {

--- a/cmd/jp/main_test.go
+++ b/cmd/jp/main_test.go
@@ -47,6 +47,20 @@ func TestParseFlags(t *testing.T) {
 			wantErr:  false,
 		},
 		{
+			name:     "with -h flag",
+			args:     []string{"-h"},
+			wantPath: "",
+			wantFile: "",
+			wantErr:  true,
+		},
+		{
+			name:     "with --help flag",
+			args:     []string{"--help"},
+			wantPath: "",
+			wantFile: "",
+			wantErr:  true,
+		},
+		{
 			name:     "invalid flag",
 			args:     []string{"-x"},
 			wantPath: "",


### PR DESCRIPTION
# 修复：改进命令行帮助信息显示

## 问题描述
1. 当用户直接运行 `jp` 命令而不提供任何参数或输入时，程序会一直等待标准输入，这不符合命令行工具的常见行为模式
2. `--help` 标志未得到支持，用户只能使用 `-h` 查看帮助信息

## 解决方案
1. 检测是否有管道输入（`isInputFromPipe`）
   - 当没有参数且没有管道输入时，显示帮助信息并退出
   - 有管道输入时，正常处理输入数据
2. 添加对 `--help` 标志的支持
   - 与 `-h` 标志行为一致
   - 显示完整的帮助信息

## 代码改进
1. 重构：
   - 将主要逻辑从 `main()` 提取到 `run()` 函数，提高代码可测试性
   - 统一错误处理方式，使用返回错误而不是直接退出
   - 改进代码结构，使其更易于测试和维护

2. 测试：
   - 添加 `TestNoInputShowsHelp` 测试用例，验证无输入时的行为
   - 扩展 `TestParseFlags` 测试用例，覆盖 `--help` 标志
   - 使用管道捕获和验证输出内容

3. 其他改进：
   - 将 `.cursorrules` 添加到 `.gitignore`，避免 IDE 配置文件进入代码库

## 影响
- 改进用户体验：符合命令行工具的常见行为模式
- 提高代码质量：更好的错误处理和测试覆盖
- 无破坏性变更：不影响现有功能

## 测试
- [x] 单元测试通过
- [x] 手动测试通过
  - `jp` 显示帮助信息
  - `jp --help` 显示帮助信息
  - `jp -h` 显示帮助信息
  - `echo '{"a":1}' | jp` 正常处理输入
  - `-p` 和 `-f` 参数行为不变

## 检查清单
- [x] 代码遵循 Go 最佳实践
- [x] 添加了必要的测试
- [x] 提交信息符合规范
- [x] 分支基于最新的 main 分支